### PR TITLE
add menu item for high quality recording

### DIFF
--- a/app/src/main/java/com/danielkim/soundrecorder/RecordingService.java
+++ b/app/src/main/java/com/danielkim/soundrecorder/RecordingService.java
@@ -6,9 +6,11 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.media.MediaRecorder;
 import android.os.Environment;
 import android.os.IBinder;
+import android.preference.PreferenceManager;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import android.widget.Toast;
@@ -77,6 +79,8 @@ public class RecordingService extends Service {
 
     public void startRecording() {
 
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
+
         setFileNameAndPath();
 
         mRecorder = new MediaRecorder();
@@ -85,6 +89,10 @@ public class RecordingService extends Service {
         mRecorder.setOutputFile(mFilePath);
         mRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC);
         mRecorder.setAudioChannels(1);
+        if (preferences.getBoolean("high_quality", true)) {
+            mRecorder.setAudioSamplingRate(44100);
+            mRecorder.setAudioEncodingBitRate(192000);
+        }
 
         try {
             mRecorder.prepare();
@@ -107,7 +115,7 @@ public class RecordingService extends Service {
             count++;
 
             mFileName = getString(R.string.default_file_name)
-                    + " #" + (mDatabase.getCount() + count) + ".mp4";
+                    + " " + (mDatabase.getCount() + count) + ".mp4";
             mFilePath = Environment.getExternalStorageDirectory().getAbsolutePath();
             mFilePath += "/SoundRecorder/" + mFileName;
 

--- a/app/src/main/java/com/danielkim/soundrecorder/activities/MainActivity.java
+++ b/app/src/main/java/com/danielkim/soundrecorder/activities/MainActivity.java
@@ -1,6 +1,8 @@
 package com.danielkim.soundrecorder.activities;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
@@ -23,6 +25,8 @@ public class MainActivity extends ActionBarActivity{
 
     private PagerSlidingTabStrip tabs;
     private ViewPager pager;
+    public SharedPreferences sharedPref;
+    private Menu mOptionsMenu;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -39,12 +43,18 @@ public class MainActivity extends ActionBarActivity{
         if (toolbar != null) {
             setSupportActionBar(toolbar);
         }
+
+        sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
     }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.menu_main, menu);
+        mOptionsMenu = menu;
+
+        MenuItem high_quality = mOptionsMenu.findItem(R.id.action_high_quality);
+        high_quality.setChecked(sharedPref.getBoolean("high_quality", true));
         return true;
     }
 
@@ -58,9 +68,21 @@ public class MainActivity extends ActionBarActivity{
             case R.id.action_licenses:
                 openLicenses();
                 return true;
+            case R.id.action_high_quality:
+                toggleQuality();
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    public void toggleQuality() {
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putBoolean("high_quality", !sharedPref.getBoolean("high_quality", true));
+        editor.commit();
+
+        MenuItem high_quality = mOptionsMenu.findItem(R.id.action_high_quality);
+        high_quality.setChecked(sharedPref.getBoolean("high_quality", true));
     }
 
     public void openLicenses(){

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -5,8 +5,14 @@
     tools:context=".MainActivity">
     <!-- View Open Source Licenses -->
     <item
-        android:id="@+id/action_licenses"
-        android:title="@string/action_licenses"
+        android:id="@+id/action_high_quality"
+        android:checkable="true"
+        android:checked="true"
+        android:enabled="true"
         android:orderInCategory="100"
-        app:showAsAction="never" />
+        android:title="@string/action_high_quality" />
+    <item
+        android:id="@+id/action_licenses"
+        android:orderInCategory="101"
+        android:title="@string/action_licenses" />
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,5 +39,6 @@
     <string name="default_file_name">Meine Aufzeichnung</string>
     <string name="record_prompt">Berühre den Button, um die Aufzeichnung zu starten</string>
     <string name="record_in_progress">Nehme auf</string>
+    <string name="action_high_quality">Hohe Qualität</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,5 +41,6 @@
     <string name="record_in_progress">Recording</string>
 
     <string name="send_to">Send to</string>
+    <string name="action_high_quality">High Quality</string>
 
 </resources>


### PR DESCRIPTION
The default recording quality on my smartphone is 8KHz @ 12 kbit/s which really does limit the usefulness of the app. I tried to keep it simple in the spirit of the app and added only a single checkbox for high quality that stores one boolean in the DefaultSharedPreferences.

Sorry for sneaking in the removal of the `#` in the filename. It caused issues with the filename that kdeconnect receives when shared. Probably a bug in kdeconnect, but using less special characters in filenames is often a good thing.